### PR TITLE
Inform there is exlpaination in next section

### DIFF
--- a/english/Chapter4-3.md
+++ b/english/Chapter4-3.md
@@ -14,7 +14,7 @@ There are certain rules for the code that is able to converted by Autograph, or 
 
 We are going to introduce the coding rules of Autograph and its mechanism of converting into static graph, together with introduction about how to construct Autograph using `tf.Module`.
 
-This section introduce the coding rules of using Autograph.
+This section introduce the coding rules of using Autograph. We will introduce the mechanisms of Autograph in next section and explain the logic behind the rules there.
 
 <!-- #region -->
 ### 1. Summarization of the Coding Rules of Autograph


### PR DESCRIPTION
Inform readers that there is exlpaination in the next section. 

When I was reading this section without looking into the next section, I googled for the mechanisms behind these rules which turned out to be meaningless.

This is probabily because we do not have a title for each English section and I am not sure whether people reading the Chinese version find it clearly. This modification is just for better chaining the chapter.