### PR TITLE
While plotting model metrics AUC throwing an error instead auc works ok

### DIFF
--- a/english/Chapter1-1.md
+++ b/english/Chapter1-1.md
@@ -295,7 +295,7 @@ plot_metric(history,"loss")
 ![](../data/1-1-Loss曲线.jpg)
 
 ```python
-plot_metric(history,"AUC")
+plot_metric(history,"auc")
 ```
 
 ![](../data/1-1-AUC曲线.jpg)


### PR DESCRIPTION
While plotting model metric you used "AUC" but it throwing an error when I checked (pd.DataFrame(history.history)) I cam to know that history.history dataframe contain auc rather than AUC.